### PR TITLE
Renamed method to fix typo

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -34,7 +34,7 @@ class ServiceProvider extends BaseServiceProvider
         }
 
         $this->registerBladeDirectives();
-        $this->registerAttributesBagMarco();
+        $this->registerAttributesBagMacro();
     }
 
     protected function registerBladeDirectives(): void
@@ -50,7 +50,7 @@ class ServiceProvider extends BaseServiceProvider
         });
     }
 
-    protected function registerAttributesBagMarco(): void
+    protected function registerAttributesBagMacro(): void
     {
         ComponentAttributeBag::macro('twMerge', function (...$args): static {
             $this->attributes['class'] = resolve(TailwindMergeContract::class)->merge($args, ($this->attributes['class'] ?? ''));


### PR DESCRIPTION
Hey @gehrisandro! Really cool package, I'm looking forward to giving it a try in one of my projects 😄

When I was just having a quick look through the code, I think I might have spotted a typo in the package's provider. I've just made a quick PR to change the spelling from `marco` to `macro`.

Hopefully, this is all okay, but apologies if it's not needed (or if I've missed anything off)!