### PR TITLE
Support conditional classes in Blade directive and attribute macro

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TailwindMerge\Laravel;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\ComponentAttributeBag;
@@ -46,14 +47,14 @@ class ServiceProvider extends BaseServiceProvider
                 return;
             }
 
-            $bladeCompiler->directive($name, fn (?string $expression) => "<?php echo twMerge($expression); ?>");
+            $bladeCompiler->directive($name, fn (?string $expression) => "<?php echo twMerge(\Illuminate\Support\Arr::map([$expression], fn (\$arg) => \Illuminate\Support\Arr::toCssClasses(\$arg))); ?>");
         });
     }
 
     protected function registerAttributesBagMacro(): void
     {
         ComponentAttributeBag::macro('twMerge', function (...$args): static {
-            $this->attributes['class'] = resolve(TailwindMergeContract::class)->merge($args, ($this->attributes['class'] ?? ''));
+            $this->attributes['class'] = resolve(TailwindMergeContract::class)->merge(Arr::map($args, fn ($arg) => Arr::toCssClasses($arg)), ($this->attributes['class'] ?? ''));
 
             return $this;
         });

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -10,6 +10,7 @@ test('service providers')
     ->expect('TailwindMerge\Laravel\ServiceProvider')
     ->toOnlyUse([
         'Illuminate\Contracts\Support\DeferrableProvider',
+        'Illuminate\Support\Arr',
         'Illuminate\Support\ServiceProvider',
         'Illuminate\View\Compilers\BladeCompiler',
         'Illuminate\View\ComponentAttributeBag',

--- a/tests/Feature/BladeComponentTest.php
+++ b/tests/Feature/BladeComponentTest.php
@@ -19,12 +19,12 @@ test('blade attribute macro supports conditional classes', function () {
         ->assertSee('<div class="w-10 h-10 bg-blue-500"></div>', false);
 
     $this->blade('<x-square class="bg-blue-500" rounded />')
-        ->assertSee('<div class="w-10 h-10 rounded bg-blue-500"></div>', false);
+        ->assertSee('<div class="w-10 h-10 rounded-lg bg-blue-500"></div>', false);
 });
 
 test('blade attribute macro supports multiple arguments', function () {
     Blade::component('rectangle', Rectangle::class);
 
     $this->blade('<x-rectangle />')
-        ->assertSee('<div class="h-6 rounded border pl-4"></div>', false);
+        ->assertSee('<div class="h-6 rounded-lg border pl-4"></div>', false);
 });

--- a/tests/Feature/BladeComponentTest.php
+++ b/tests/Feature/BladeComponentTest.php
@@ -2,10 +2,29 @@
 
 use Illuminate\Support\Facades\Blade;
 use Tests\Fixtures\Circle;
+use Tests\Fixtures\Rectangle;
+use Tests\Fixtures\Square;
 
-it('provides a blade directive to merge tailwind classes', function () {
+it('provides a blade attribute macro to merge tailwind classes', function () {
     Blade::component('circle', Circle::class);
 
     $this->blade('<x-circle class="bg-blue-500" />')
         ->assertSee('<div class="w-10 h-10 rounded-full bg-blue-500"></div>', false);
+});
+
+test('blade attribute macro supports conditional classes', function () {
+    Blade::component('square', Square::class);
+
+    $this->blade('<x-square class="bg-blue-500" />')
+        ->assertSee('<div class="w-10 h-10 bg-blue-500"></div>', false);
+
+    $this->blade('<x-square class="bg-blue-500" rounded />')
+        ->assertSee('<div class="w-10 h-10 rounded bg-blue-500"></div>', false);
+});
+
+test('blade attribute macro supports multiple arguments', function () {
+    Blade::component('rectangle', Rectangle::class);
+
+    $this->blade('<x-rectangle />')
+        ->assertSee('<div class="h-6 rounded border pl-4"></div>', false);
 });

--- a/tests/Feature/BladeDirectiveTest.php
+++ b/tests/Feature/BladeDirectiveTest.php
@@ -10,20 +10,20 @@ it('provides a blade directive to merge tailwind classes', function () {
 test('blade directive supports conditional classes', function () {
     $this->blade('<div class="@twMerge([
         "h-4 h-6",
-        "rounded" => false,
+        "rounded-lg" => false,
     ])"></div>')
         ->assertSee('class="h-6"', false);
 
     $this->blade('<div class="@twMerge([
         "h-4 h-6",
-        "rounded" => true,
+        "rounded-lg" => true,
     ])"></div>')
-        ->assertSee('class="h-6 rounded"', false);
+        ->assertSee('class="h-6 rounded-lg"', false);
 });
 
 test('blade directive supports multiple arguments', function () {
-    $this->blade('<div class="@twMerge("h-4 h-6", "rounded border", ["pl-4", "rounded-full" => false])"></div>')
-        ->assertSee('class="h-6 rounded border pl-4"', false);
+    $this->blade('<div class="@twMerge("h-4 h-6", "rounded-lg border", ["pl-4", "rounded-full" => false])"></div>')
+        ->assertSee('class="h-6 rounded-lg border pl-4"', false);
 });
 
 test('name ot the blade directive is configurable', function () {

--- a/tests/Feature/BladeDirectiveTest.php
+++ b/tests/Feature/BladeDirectiveTest.php
@@ -7,6 +7,25 @@ it('provides a blade directive to merge tailwind classes', function () {
         ->assertSee('class="h-6"', false);
 });
 
+test('blade directive supports conditional classes', function () {
+    $this->blade('<div class="@twMerge([
+        "h-4 h-6",
+        "rounded" => false,
+    ])"></div>')
+        ->assertSee('class="h-6"', false);
+
+    $this->blade('<div class="@twMerge([
+        "h-4 h-6",
+        "rounded" => true,
+    ])"></div>')
+        ->assertSee('class="h-6 rounded"', false);
+});
+
+test('blade directive supports multiple arguments', function () {
+    $this->blade('<div class="@twMerge("h-4 h-6", "rounded border", ["pl-4", "rounded-full" => false])"></div>')
+        ->assertSee('class="h-6 rounded border pl-4"', false);
+});
+
 test('name ot the blade directive is configurable', function () {
     Config::set('tailwind-merge.blade_directive', 'myMerge');
 

--- a/tests/Fixtures/Rectangle.php
+++ b/tests/Fixtures/Rectangle.php
@@ -9,7 +9,7 @@ class Rectangle extends Component
     public function render()
     {
         return <<<'blade'
-            <div {{ $attributes->twMerge("h-4 h-6", "rounded border", ["pl-4", "rounded-full" => false]) }}></div>
+            <div {{ $attributes->twMerge("h-4 h-6", "rounded-lg border", ["pl-4", "rounded-full" => false]) }}></div>
         blade;
     }
 }

--- a/tests/Fixtures/Rectangle.php
+++ b/tests/Fixtures/Rectangle.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace tests\Fixtures;
+
+use Illuminate\View\Component;
+
+class Rectangle extends Component
+{
+    public function render()
+    {
+        return <<<'blade'
+            <div {{ $attributes->twMerge("h-4 h-6", "rounded border", ["pl-4", "rounded-full" => false]) }}></div>
+        blade;
+    }
+}

--- a/tests/Fixtures/Square.php
+++ b/tests/Fixtures/Square.php
@@ -16,7 +16,7 @@ class Square extends Component
         return <<<"blade"
             <div {{ \$attributes->twMerge([
                 'w-10 h-10 bg-red-500',
-                'rounded' => '{$this->rounded}',
+                'rounded-lg' => '{$this->rounded}',
             ]) }}></div>
         blade;
     }

--- a/tests/Fixtures/Square.php
+++ b/tests/Fixtures/Square.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace tests\Fixtures;
+
+use Illuminate\View\Component;
+
+class Square extends Component
+{
+    public function __construct(
+        public bool $rounded = false,
+    ) {
+    }
+
+    public function render()
+    {
+        return <<<"blade"
+            <div {{ \$attributes->twMerge([
+                'w-10 h-10 bg-red-500',
+                'rounded' => '{$this->rounded}',
+            ]) }}></div>
+        blade;
+    }
+}


### PR DESCRIPTION
This PR adds support for conditional classes to the Blade directive and attribute macro, just like Blade's existing `@class` directive and `$attrbutes->class()` method support. Allowing you to do:

```blade
<div class="@twMerge([
    'h-4 h-6',
    'rounded-lg' => $someCondition,
])"></div>
```

Tests are included and I've added a couple of extra tests to ensure that multiple arguments all still work as expected.