### PR TITLE
Fix configuration file publish instruction in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ First, install `TailwindMerge for Laravel` via the [Composer](https://getcompose
 composer require gehrisandro/tailwind-merge-laravel
 ```
 
-Next, publish the configuration file:
+Optionally, publish the configuration file:
 
 ```bash
-php artisan vendor:publish --provider="TailwindMerge\Laravel\ServiceProvider"
+php artisan vendor:publish --provider="TailwindMerge\Laravel\TailwindMergeServiceProvider"
 ```
 
 This will create a `config/tailwind-merge.php` configuration file in your project, which you can modify to your needs


### PR DESCRIPTION
This MR fixes the service provider class name in the publish instruction and marks that step as optional.

The package (in its current state anyway) works perfectly fine skipping this step.