### PR TITLE
Make cache store configurable

### DIFF
--- a/config/tailwind-merge.php
+++ b/config/tailwind-merge.php
@@ -5,6 +5,17 @@ declare(strict_types=1);
 return [
     /*
     |--------------------------------------------------------------------------
+    | Cache Store
+    |--------------------------------------------------------------------------
+    |
+    | Tailwind Merge uses Laravel's cache system to store the merged classes.
+    | Here you can customize the cache store that Tailwind Merge uses.
+    */
+
+    'cache_store' => env('TAILWIND_MERGE_CACHE_STORE'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Prefix
     |--------------------------------------------------------------------------
     |

--- a/src/TailwindMergeServiceProvider.php
+++ b/src/TailwindMergeServiceProvider.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace TailwindMerge\Laravel;
 
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\ServiceProvider as BaseServiceProvider;
 use Illuminate\View\Compilers\BladeCompiler;
 use Illuminate\View\ComponentAttributeBag;
+use Psr\SimpleCache\CacheInterface;
 use TailwindMerge\Contracts\TailwindMergeContract;
 use TailwindMerge\TailwindMerge;
 
@@ -14,9 +16,9 @@ class TailwindMergeServiceProvider extends BaseServiceProvider
 {
     public function register(): void
     {
-        $this->app->singleton(TailwindMergeContract::class, static fn (): TailwindMerge => TailwindMerge::factory()
+        $this->app->singleton(TailwindMergeContract::class, fn (): TailwindMerge => TailwindMerge::factory()
             ->withConfiguration(config('tailwind-merge', []))
-            ->withCache(app('cache')->store()) // @phpstan-ignore-line
+            ->withCache($this->getCacheStore())
             ->make());
 
         $this->app->alias(TailwindMergeContract::class, 'tailwind-merge');
@@ -89,5 +91,13 @@ class TailwindMergeServiceProvider extends BaseServiceProvider
             TailwindMergeContract::class,
             'tailwind-merge',
         ];
+    }
+
+    protected function getCacheStore(): CacheInterface
+    {
+        /** @var string|null $storage */
+        $storage = config('tailwind-merge.cache_store');
+
+        return Cache::store($storage);
     }
 }

--- a/tests/Arch.php
+++ b/tests/Arch.php
@@ -12,9 +12,11 @@ test('service providers')
     ->expect('TailwindMerge\Laravel\TailwindMergeServiceProvider')
     ->toOnlyUse([
         'Illuminate\Contracts\Support\DeferrableProvider',
+        'Illuminate\Support\Facades\Cache',
         'Illuminate\Support\ServiceProvider',
         'Illuminate\View\Compilers\BladeCompiler',
         'Illuminate\View\ComponentAttributeBag',
+        'Psr\SimpleCache\CacheInterface',
         'TailwindMerge',
 
         // helpers...


### PR DESCRIPTION
On my project I use Redis as my default cache store, I noticed that the package right now uses cache (the default store) to not compute the same thing all over again, but I think doing a network request to Redis is expensive, by making the cache store configurable you can optimize this to use the "file" store.

Just an idea, on my project solved it by extending the service provider and making my changes, but the package is awesome and wanted to contribute with this idea back