### PR TITLE
Update CI workflows and dependencies for Laravel 13

### DIFF
--- a/.github/workflows/formats.yml
+++ b/.github/workflows/formats.yml
@@ -10,8 +10,8 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2]
-        dependency-version: [prefer-lowest, prefer-stable]
+        php: [8.4]
+        dependency-version: [prefer-stable]
 
     name: Formats P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
@@ -21,7 +21,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Cache dependencies
-      uses: actions/cache@v1
+      uses: actions/cache@v3
       with:
         path: ~/.composer/cache/files
         key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.2, 8.3, 8.4]
+        php: [8.2, 8.3, 8.4, 8.5]
         laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,53 +1,60 @@
 name: Tests
 
-on: ['push', 'pull_request']
+on:
+  - push
+  - pull_request
 
 jobs:
   ci:
     runs-on: ${{ matrix.os }}
+
     strategy:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1, 8.2, 8.3]
-        laravel: [10.*, 11.*]
+        php: [8.2, 8.3, 8.4]
+        laravel: ['11.*', '12.*', '13.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: ^8.20
           - lararavel: 11.*
             testbench: ^9.0
+          - laravel: 12.*
+            testbench: ^10.0
+          - laravel: 13.*
+            testbench: ^11.0
         exclude:
-          - php: 8.1
-            laravel: 11.*
+          - laravel: 13.*
+            php: 8.2
+          - php: 8.2
+            laravel: 13.*
+
 
     name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
 
-    - name: Checkout
-      uses: actions/checkout@v2
+      - name: Cache dependencies
+        uses: actions/cache@v3
+        with:
+          path: ~/.composer/cache/files
+          key: dependencies-php-${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
 
-    - name: Cache dependencies
-      uses: actions/cache@v1
-      with:
-        path: ~/.composer/cache/files
-        key: dependencies-php-${{ matrix.php }}-L${{ matrix.laravel }}-${{ matrix.dependency-version }}-composer-${{ hashFiles('composer.json') }}
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, mbstring, zip
+          coverage: none
 
-    - name: Setup PHP
-      uses: shivammathur/setup-php@v2
-      with:
-        php-version: ${{ matrix.php }}
-        extensions: dom, mbstring, zip
-        coverage: none
+      - name: Require Laravel Version
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
 
-    - name: Require Laravel Version
-      run: >
-        composer require
-        "laravel/framework:${{ matrix.laravel }}"
-        --no-interaction --no-update
+      - name: Install Composer dependencies
+        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
-    - name: Install Composer dependencies
-      run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
+      - name: Integration Tests
+        run: php ./vendor/bin/pest
 
-    - name: Integration Tests
-      run: php ./vendor/bin/pest

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,13 @@
 {
     "name": "gehrisandro/tailwind-merge-laravel",
     "description": "TailwindMerge for Laravel merges multiple Tailwind CSS classes by automatically resolving conflicts between them",
-    "keywords": ["laravel", "php", "tailwindcss", "merge", "classes"],
+    "keywords": [
+        "laravel",
+        "php",
+        "tailwindcss",
+        "merge",
+        "classes"
+    ],
     "license": "MIT",
     "authors": [
         {
@@ -12,18 +18,17 @@
     "require": {
         "php": "^8.1.0",
         "guzzlehttp/guzzle": "^7.5.1",
-        "laravel/framework": "^10.9.0|^11.0",
+        "laravel/framework": "^10.9.0|^11.0|^12.0|^13.0",
         "gehrisandro/tailwind-merge-php": "^v1.1.0"
     },
     "require-dev": {
         "laravel/pint": "^1.13.8",
-        "orchestra/testbench": "^8.0|^9.0",
-        "pestphp/pest": "^v2.30.0",
-        "pestphp/pest-plugin-arch": "^2.6",
-        "pestphp/pest-plugin-mock": "^2.0.0",
-        "pestphp/pest-plugin-type-coverage": "^2.8",
-        "phpstan/phpstan": "^1.10.55",
-        "rector/rector": "^0.19",
+        "orchestra/testbench": "^8.0|^9.0|^10.0|^11.0",
+        "pestphp/pest": "^v2.30.0|^3.7",
+        "pestphp/pest-plugin-arch": "^2.6|^3.0",
+        "pestphp/pest-plugin-type-coverage": "^2.8|^3.3",
+        "phpstan/phpstan": "^1.10.55|^2.1",
+        "rector/rector": "^0.19|^2.0",
         "symfony/var-dumper": "^6.4.2|^7.0"
     },
     "autoload": {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,21 +1,37 @@
 parameters:
 	ignoreErrors:
 		-
-			message: "#^Cannot call method merge\\(\\) on mixed\\.$#"
+			message: '#^Parameter \#1 \$configuration of method TailwindMerge\\Factory\:\:withConfiguration\(\) expects array\<string, mixed\>, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/TailwindMergeServiceProvider.php
 
 		-
-			message: "#^Parameter \\#1 \\$configuration of method TailwindMerge\\\\Factory\\:\\:withConfiguration\\(\\) expects array\\<string, mixed\\>, mixed given\\.$#"
+			message: '#^Parameter \#1 \$name of method Illuminate\\View\\Compilers\\BladeCompiler\:\:directive\(\) expects string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/TailwindMergeServiceProvider.php
 
 		-
-			message: "#^Parameter \\#1 \\$name of method Illuminate\\\\View\\\\Compilers\\\\BladeCompiler\\:\\:directive\\(\\) expects string, mixed given\\.$#"
+			message: '#^Parameter \#1 \.\.\.\$args of method TailwindMerge\\Contracts\\TailwindMergeContract\:\:merge\(\) expects array\<array\<string\>\|string\>\|string, array\<int\|string, mixed\> given\.$#'
+			identifier: argument.type
+			count: 2
+			path: src/TailwindMergeServiceProvider.php
+
+		-
+			message: '#^Parameter \#2 \.\.\.\$args of method TailwindMerge\\Contracts\\TailwindMergeContract\:\:merge\(\) expects array\<array\<string\>\|string\>\|string, mixed given\.$#'
+			identifier: argument.type
 			count: 1
 			path: src/TailwindMergeServiceProvider.php
 
 		-
-			message: "#^Cannot call method merge\\(\\) on mixed\\.$#"
+			message: '#^Cannot call method merge\(\) on mixed\.$#'
+			identifier: method.nonObject
+			count: 1
+			path: src/helpers.php
+
+		-
+			message: '#^Function twMerge\(\) should return string but returns mixed\.$#'
+			identifier: return.type
 			count: 1
 			path: src/helpers.php

--- a/rector.php
+++ b/rector.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\LevelSetList;
 use Rector\Set\ValueObject\SetList;
+use Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector;
 
 return static function (RectorConfig $rectorConfig): void {
     $rectorConfig->paths([
@@ -12,7 +13,7 @@ return static function (RectorConfig $rectorConfig): void {
     ]);
 
     $rectorConfig->skip([
-        \Rector\Php74\Rector\Closure\ClosureToArrowFunctionRector::class => [
+        ClosureToArrowFunctionRector::class => [
             __DIR__ . '/src/TailwindMergeServiceProvider.php',
         ],
     ]);

--- a/src/TailwindMergeServiceProvider.php
+++ b/src/TailwindMergeServiceProvider.php
@@ -80,7 +80,7 @@ class TailwindMergeServiceProvider extends BaseServiceProvider
     }
 
     /**
-     * @return array<class-string<\TailwindMerge\Contracts\TailwindMergeContract>>|string[]
+     * @return array<class-string<TailwindMergeContract>>|string[]
      */
     public function provides(): array
     {

--- a/tests/Feature/CacheTest.php
+++ b/tests/Feature/CacheTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Event;
 use TailwindMerge\TailwindMerge;
+use Illuminate\Cache\Events\CacheHit;
+use Illuminate\Cache\Events\CacheMissed;
 
 it('uses caching', function () {
     Event::fake();
@@ -12,11 +14,11 @@ it('uses caching', function () {
 
     expect($twMerge->merge('h-4 h-6'))->toBe('h-6');
 
-    Event::assertDispatched(\Illuminate\Cache\Events\CacheMissed::class, 1);
-    Event::assertNotDispatched(\Illuminate\Cache\Events\CacheHit::class);
+    Event::assertDispatched(CacheMissed::class, 1);
+    Event::assertNotDispatched(CacheHit::class);
 
     expect($twMerge->merge('h-4 h-6'))->toBe('h-6');
 
-    Event::assertDispatched(\Illuminate\Cache\Events\CacheMissed::class, 1);
-    Event::assertDispatched(\Illuminate\Cache\Events\CacheHit::class, 2);
+    Event::assertDispatched(CacheMissed::class, 1);
+    Event::assertDispatched(CacheHit::class, 2);
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,10 +1,13 @@
 <?php
 
 declare(strict_types=1);
+use Illuminate\Foundation\Testing\Concerns\InteractsWithContainer;
+use Illuminate\Foundation\Testing\Concerns\InteractsWithViews;
+use Tests\TestCase;
 
 uses(
-    \Illuminate\Foundation\Testing\Concerns\InteractsWithContainer::class,
-    \Illuminate\Foundation\Testing\Concerns\InteractsWithViews::class,
-    \Tests\TestCase::class,
+    InteractsWithContainer::class,
+    InteractsWithViews::class,
+    TestCase::class,
 )
     ->in(__DIR__);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,8 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     use InteractsWithViews;
 
+    public static mixed $latestResponse = null; // fix for testbench v9.x
+
     protected function getPackageProviders($app): array
     {
         return [


### PR DESCRIPTION
This PR updates the package’s compatibility matrix to support Laravel 13 and aligns the test infrastructure with currently supported platform versions.

What changed

- Added support for laravel/framework:^13.0
- Added support for orchestra/testbench:^11.0
- Expanded the CI matrix to cover Laravel 13 combinations
- Removed PHP 8.1 from CI (EOL)
- Removed Laravel 10 from the CI matrix
- Updated GitHub Actions caching to actions/cache@v3
- Moved formatting checks to PHP 8.4
- Applied minor compatibility and tooling updates required for newer Testbench versions

Notes

These changes are primarily focused on dependency compatibility and CI maintenance, with a few small test and typing adjustments needed to keep the suite green across the updated matrix.